### PR TITLE
add module transformer

### DIFF
--- a/src/sagemaker_mxnet_serving_container/mxnet_module_transformer.py
+++ b/src/sagemaker_mxnet_serving_container/mxnet_module_transformer.py
@@ -32,8 +32,12 @@ class MXNetModuleTransformer(Transformer):
         return result
 
     # The default_input_fn for Modules requires access to the model object.
-    # The input_fn contract only allows access to two parameters.
-    # To not break input_fn that are only expecting two parameters.
+    # Originally, the input_fn allowed for input_data, content_type and model.
+    # https://github.com/aws/sagemaker-python-sdk/tree/a6b26d63e1420bf2283d7981f46a9f58b9163165#model-serving
+    # However, the current documentation indicates only two parameters:
+    # input_data and content_type
+    # Thus the following has to be added to not break input_fn that are
+    # abiding with the current documentation.
     def _call_input_fn(self, input_data, content_type, model):
         try:  # PY3
             argspec = inspect.getfullargspec(self._input_fn)

--- a/test/unit/test_mxnet_module_transformer.py
+++ b/test/unit/test_mxnet_module_transformer.py
@@ -20,10 +20,10 @@ CONTENT_TYPE = 'content'
 ACCEPT = 'accept'
 DATA = 'data'
 MODEL = 'foo'
-EMPTY_ARG_SPEC = list()
-ARG_SPEC_WITH_MODEL = ['model']
 
 PREPROCESSED_DATA = 'preprocessed_data'
+PREDICT_RESULT = 'prediction_result'
+PROCESSED_RESULT = 'processed_result'
 
 
 def _input_fn_with_model(input_data, content_type, model):
@@ -32,11 +32,8 @@ def _input_fn_with_model(input_data, content_type, model):
 
 @patch('importlib.import_module', return_value=object())
 def test_default_transform_fn(import_module):
-    prediction_result = 'result'
-    processed_result = 'processed_result'
-
-    predict_fn = Mock(return_value=prediction_result)
-    output_fn = Mock(return_value=processed_result)
+    predict_fn = Mock(return_value=PREDICT_RESULT)
+    output_fn = Mock(return_value=PROCESSED_RESULT)
 
     module_transformer = MXNetModuleTransformer()
     module_transformer._input_fn = _input_fn_with_model
@@ -46,8 +43,8 @@ def test_default_transform_fn(import_module):
     result = module_transformer._default_transform_fn(MODEL, DATA, CONTENT_TYPE, ACCEPT)
 
     predict_fn.assert_called_once_with(PREPROCESSED_DATA, MODEL)
-    output_fn.assert_called_once_with(prediction_result, ACCEPT)
-    assert processed_result == result
+    output_fn.assert_called_once_with(PREDICT_RESULT, ACCEPT)
+    assert PROCESSED_RESULT == result
 
 
 @patch('importlib.import_module', return_value=object())


### PR DESCRIPTION
Add MXNet Module Transformer to use in conjunction with the default_input_fn that requires access to the model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
