### PR TITLE
test content type header

### DIFF
--- a/test/integration/local/test_default_model_fn.py
+++ b/test/integration/local/test_default_model_fn.py
@@ -48,6 +48,7 @@ def test_default_model_fn(predictor):
     assert [[4.9999918937683105]] == output
 
 
-def test_default_model_fn_via_requests(predictor):
+def test_default_model_fn_content_type(predictor):
     r = requests.post('http://localhost:8080/invocations', json=[[1, 2]])
+    assert 'application/json' == r.headers['Content-Type']
     assert [[4.9999918937683105]] == r.json()


### PR DESCRIPTION
Initially removed, however support was added in sagemaker-inference.

This line: https://github.com/aws/sagemaker-mxnet-container/blob/master/test/integration/local/test_default_model_fn.py#L48