### PR TITLE
Add link to SageMaker integ test setup requirements to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,7 @@ SageMaker Integration Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SageMaker integration tests require your Docker image to be within an `Amazon ECR repository <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_Console_Repositories.html>`__.
+They also require that you have the setup described under "Integration Tests" at https://github.com/aws/sagemaker-python-sdk#running-tests.
 
 SageMaker integration tests use the following pytest arguments:
 


### PR DESCRIPTION
*Description of changes:*
https://github.com/aws/sagemaker-python-sdk/pull/865 contains changes that describe the needed permissions for running EI tests, which is what inspired this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
