### PR TITLE
Fix shell command in entrypoint

### DIFF
--- a/docker/1.4.1/mms-entrypoint.py
+++ b/docker/1.4.1/mms-entrypoint.py
@@ -1,3 +1,4 @@
+import shlex
 import subprocess
 import sys
 
@@ -6,7 +7,7 @@ from sagemaker_mxnet_serving_container import serving
 if sys.argv[1] == 'serve':
     serving.main()
 else:
-    subprocess.check_call(sys.argv[1:])
+    subprocess.check_call(shlex.split(' '.join(sys.argv[1:])))
 
 # prevent docker exit
 subprocess.call(['tail', '-f', '/dev/null'])


### PR DESCRIPTION
The old entrypoint simply used `$@` in shell, so using quotes in the command like `'mxnet-model-server' '--start' '--mms-config /tmp/foo'` didn't matter, but that kind of list doesn't work with `subprocess.check_call`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
