### PR TITLE
Change CMD to emulate old "serve" command

### DIFF
--- a/docker/1.4.1/Dockerfile.cpu
+++ b/docker/1.4.1/Dockerfile.cpu
@@ -70,4 +70,4 @@ RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
 EXPOSE 8080 8081
 ENV TEMP=/home/model-server/tmp
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["serve"]
+CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.4.1/Dockerfile.gpu
+++ b/docker/1.4.1/Dockerfile.gpu
@@ -70,4 +70,4 @@ RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
 EXPOSE 8080 8081
 ENV TEMP=/home/model-server/tmp
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["serve"]
+CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]


### PR DESCRIPTION
*Description of changes:*
realized I didn't quite address the problem I described in #24, so this PR should do that.

```
$ docker run -it -p 80:8080 -p 8081:8081 preprod-mxnet-serving:1.4.1-cpu-py3
2019-06-21 23:38:01,018 [INFO ] main com.amazonaws.ml.mms.ModelServer -
MMS Home: /usr/local/lib/python3.6/site-packages
Current directory: /
Temp directory: /home/model-server/tmp
Number of GPUs: 0
Number of CPUs: 2
Max heap size: 128 M
Python executable: /usr/local/bin/python3.6
Config file: /home/model-server/config.properties
Inference address: http://0.0.0.0:8080
Management address: http://0.0.0.0:8081
Model Store: /opt/ml/model
Initial Models: ALL
Log dir: /logs
Metrics dir: /logs
Netty threads: 0
Netty client threads: 0
Default workers per model: 2
Blacklist Regex: N/A
Maximum Response Size: 6553500
Maximum Request Size: 6553500
2019-06-21 23:38:01,039 [WARN ] main com.amazonaws.ml.mms.ModelServer - Model store path is not found: /opt/ml/model
2019-06-21 23:38:01,052 [INFO ] main com.amazonaws.ml.mms.ModelServer - Initialize Inference server with: EpollServerSocketChannel.
2019-06-21 23:38:01,267 [INFO ] main com.amazonaws.ml.mms.ModelServer - Inference API bind to: http://0.0.0.0:8080
2019-06-21 23:38:01,267 [INFO ] main com.amazonaws.ml.mms.ModelServer - Initialize Management server with: EpollServerSocketChannel.
2019-06-21 23:38:01,273 [INFO ] main com.amazonaws.ml.mms.ModelServer - Management API bind to: http://0.0.0.0:8081
Model server started.
2019-06-21 23:38:01,420 [INFO ] pool-2-thread-1 MMS_METRICS - CPUUtilization.Percent:0.0|#Level:Host|#hostname:08255cda2918,timestamp:1561160281
2019-06-21 23:38:01,423 [INFO ] pool-2-thread-1 MMS_METRICS - DiskAvailable.Gigabytes:17.82421875|#Level:Host|#hostname:08255cda2918,timestamp:1561160281
2019-06-21 23:38:01,423 [INFO ] pool-2-thread-1 MMS_METRICS - DiskUsage.Gigabytes:37.59777069091797|#Level:Host|#hostname:08255cda2918,timestamp:1561160281
2019-06-21 23:38:01,425 [INFO ] pool-2-thread-1 MMS_METRICS - DiskUtilization.Percent:67.8|#Level:Host|#hostname:08255cda2918,timestamp:1561160281
2019-06-21 23:38:01,428 [INFO ] pool-2-thread-1 MMS_METRICS - MemoryAvailable.Megabytes:1564.1484375|#Level:Host|#hostname:08255cda2918,timestamp:1561160281
2019-06-21 23:38:01,429 [INFO ] pool-2-thread-1 MMS_METRICS - MemoryUsed.Megabytes:260.64453125|#Level:Host|#hostname:08255cda2918,timestamp:1561160281
2019-06-21 23:38:01,431 [INFO ] pool-2-thread-1 MMS_METRICS - MemoryUtilization.Percent:21.8|#Level:Host|#hostname:08255cda2918,timestamp:1561160281
2019-06-21 23:38:03,614 [INFO ] epollEventLoopGroup-3-1 ACCESS_LOG - /172.17.0.1:49146 "POST /soap HTTP/1.1" 404 131
2019-06-21 23:38:03,614 [INFO ] epollEventLoopGroup-3-1 MMS_METRICS - Requests4XX.Count:1|#Level:Host|#hostname:08255cda2918,timestamp:null

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
