### PR TITLE
change: parametrize Python version and processor type in integ tests

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -37,9 +37,8 @@ phases:
       # build images
       - python3 scripts/build_all.py --version $FRAMEWORK_FULL_VERSION --account $ACCOUNT --repo $ECR_REPO
 
-      # run cpu integration tests
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --py-version 3 --processor cpu --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --py-version 2 --processor cpu --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO
+      # run cpu local integration tests
+      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --py-version 2,3 --processor cpu --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO
 
       # push docker images to ECR
       - python3 scripts/publish_all.py --version $FRAMEWORK_FULL_VERSION --account $ACCOUNT --repo $ECR_REPO
@@ -48,22 +47,17 @@ phases:
       - create-key-pair
       - launch-ec2-instance --instance-type $GPU_INSTANCE_TYPE --ami-name dlami-ubuntu
 
-      # run gpu integration tests
+      # run gpu local integration tests
       - printf "$SETUP_CMDS" > $SETUP_FILE
       - ecr_image="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --processor gpu --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ecr_image"
-      - remote-test --test-cmd "$cmd --py-version 3" --github-repo $GITHUB_REPO --branch master --setup-file $SETUP_FILE
-      - remote-test --test-cmd "$cmd --py-version 2" --github-repo $GITHUB_REPO --branch master --skip-setup
+      - remote-test --test-cmd "$cmd --py-version 2,3" --github-repo $GITHUB_REPO --branch master --setup-file $SETUP_FILE
 
       # run sagemaker integration tests
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 3 --processor cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 3 --processor gpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 2 --processor cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 2 --processor gpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
+      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 16 --py-version 2,3 --processor cpu,gpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
 
       # run ei tests
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_elastic_inference.py --py-version 3 --processor cpu --accelerator-type $EI_ACCELERATOR_TYPE --region $AWS_DEFAULT_REGION --docker-base-name "$ECR_REPO-eia" --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_elastic_inference.py --py-version 2 --processor cpu --accelerator-type $EI_ACCELERATOR_TYPE --region $AWS_DEFAULT_REGION --docker-base-name "$ECR_REPO-eia" --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
+      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_elastic_inference.py -n 2 --py-version 2,3 --processor cpu --accelerator-type $EI_ACCELERATOR_TYPE --region $AWS_DEFAULT_REGION --docker-base-name "$ECR_REPO-eia" --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
 
       # write deployment details to file
       # TODO: remove hardcoded AWS account number once it's configurable per region
@@ -84,10 +78,7 @@ phases:
             "dest": ["'$FRAMEWORK_FULL_VERSION'-gpu-py3", "'$FRAMEWORK_SHORT_VERSION'-gpu-py3", "'$FRAMEWORK_FULL_VERSION'-gpu-py3-'${CODEBUILD_BUILD_ID#*:}'"]
           }],
           "test": [
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_hosting.py --py-version 3 --processor cpu --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'",
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_hosting.py --py-version 3 --processor gpu --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'",
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_hosting.py --py-version 2 --processor cpu --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'",
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_hosting.py --py-version 2 --processor gpu --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'"
+            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_hosting.py -n 4 --py-version 2,3 --processor cpu,gpu --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'"
           ]
         }, {
           "repository": "'$ECR_REPO'-eia",
@@ -99,8 +90,7 @@ phases:
             "dest": ["'$FRAMEWORK_FULL_VERSION'-cpu-py3", "'$FRAMEWORK_SHORT_VERSION'-cpu-py3", "'$FRAMEWORK_FULL_VERSION'-cpu-py3-'${CODEBUILD_BUILD_ID#*:}'"]
           }],
           "test": [
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_elastic_inference.py --py-version 3 --processor cpu --accelerator-type '$EI_ACCELERATOR_TYPE' --region {region} --docker-base-name '$ECR_REPO'-eia --aws-id '$ACCOUNT' --framework-version '$FRAMEWORK_FULL_VERSION'",
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_elastic_inference.py --py-version 2 --processor cpu --accelerator-type '$EI_ACCELERATOR_TYPE' --region {region} --docker-base-name '$ECR_REPO'-eia --aws-id '$ACCOUNT' --framework-version '$FRAMEWORK_FULL_VERSION'"
+            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_elastic_inference.py -n 2 --py-version 2,3 --processor cpu --accelerator-type '$EI_ACCELERATOR_TYPE' --region {region} --docker-base-name '$ECR_REPO'-eia --aws-id '$ACCOUNT' --framework-version '$FRAMEWORK_FULL_VERSION'"
           ]
         }]' > deployments.json
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -36,13 +36,23 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='preprod-mxnet-serving')
     parser.addoption('--region', default='us-west-2')
     parser.addoption('--framework-version', default=MXNet.LATEST_VERSION)
-    parser.addoption('--py-version', default='3', choices=['2', '3'])
-    parser.addoption('--processor', default='cpu', choices=['gpu', 'cpu'])
+    parser.addoption('--py-version', default='3', choices=['2', '3', '2,3'])
+    parser.addoption('--processor', default='cpu', choices=['gpu', 'cpu', 'cpu,gpu'])
     parser.addoption('--aws-id', default=None)
     parser.addoption('--instance-type', default=None)
     parser.addoption('--accelerator-type', default=None)
     # If not specified, will default to {framework-version}-{processor}-py{py-version}
     parser.addoption('--tag', default=None)
+
+
+def pytest_generate_tests(metafunc):
+    if 'py_version' in metafunc.fixturenames:
+        py_version_params = ['py' + v for v in metafunc.config.getoption('--py-version').split(',')]
+        metafunc.parametrize('py_version', py_version_params, scope='session')
+
+    if 'processor' in metafunc.fixturenames:
+        processor_params = metafunc.config.getoption('--processor').split(',')
+        metafunc.parametrize('processor', processor_params, scope='session')
 
 
 @pytest.fixture(scope='session')
@@ -61,16 +71,6 @@ def framework_version(request):
 
 
 @pytest.fixture(scope='session')
-def py_version(request):
-    return int(request.config.getoption('--py-version'))
-
-
-@pytest.fixture(scope='session')
-def processor(request):
-    return request.config.getoption('--processor')
-
-
-@pytest.fixture(scope='session')
 def aws_id(request):
     return request.config.getoption('--aws-id')
 
@@ -78,7 +78,7 @@ def aws_id(request):
 @pytest.fixture(scope='session')
 def tag(request, framework_version, processor, py_version):
     provided_tag = request.config.getoption('--tag')
-    default_tag = '{}-{}-py{}'.format(framework_version, processor, py_version)
+    default_tag = '{}-{}-{}'.format(framework_version, processor, py_version)
     return provided_tag if provided_tag is not None else default_tag
 
 


### PR DESCRIPTION
*Description of changes:*
same as https://github.com/aws/sagemaker-mxnet-container/pull/96

*Testing done:*
```
$ pytest test/integration/ --collect-only
======== test session starts ========
[...]
collected 8 items                                                                                                                                                                                                                                                                                                                                                        
<Module test/integration/local/test_default_model_fn.py>
  <Function test_default_model_fn[py3-cpu]>
  <Function test_default_model_fn_content_type[py3-cpu]>
<Module test/integration/local/test_gluon_hosting.py>
  <Function test_gluon_hosting[py3-cpu]>
<Module test/integration/local/test_hosting.py>
  <Function test_hosting[py3-cpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_import[py3-cpu]>
<Package ~/Documents/workspace/sagemaker-mxnet-serving-container/test/integration/sagemaker>
  <Module test_batch_transform.py>
    <Function test_batch_transform[py3-cpu]>
  <Module test_elastic_inference.py>
    <Function test_elastic_inference[py3-cpu]>
  <Module test_hosting.py>
    <Function test_hosting[py3-cpu]>

$ pytest test/integration/ --processor cpu,gpu --py-version 2,3 --collect-only
======== test session starts ========
[...]
collected 32 items                                                                                                                                                                                                                                                                                                                                                       
<Module test/integration/local/test_default_model_fn.py>
  <Function test_default_model_fn[py2-cpu]>
  <Function test_default_model_fn_content_type[py2-cpu]>
<Module test/integration/local/test_gluon_hosting.py>
  <Function test_gluon_hosting[py2-cpu]>
<Module test/integration/local/test_hosting.py>
  <Function test_hosting[py2-cpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_import[py2-cpu]>
<Package ~/Documents/workspace/sagemaker-mxnet-serving-container/test/integration/sagemaker>
  <Module test_batch_transform.py>
    <Function test_batch_transform[py2-cpu]>
  <Module test_elastic_inference.py>
    <Function test_elastic_inference[py2-cpu]>
  <Module test_hosting.py>
    <Function test_hosting[py2-cpu]>
<Module test/integration/local/test_default_model_fn.py>
  <Function test_default_model_fn[py2-gpu]>
  <Function test_default_model_fn_content_type[py2-gpu]>
<Module test/integration/local/test_gluon_hosting.py>
  <Function test_gluon_hosting[py2-gpu]>
<Module test/integration/local/test_hosting.py>
  <Function test_hosting[py2-gpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_import[py2-gpu]>
<Package ~/Documents/workspace/sagemaker-mxnet-serving-container/test/integration/sagemaker>
  <Module test_batch_transform.py>
    <Function test_batch_transform[py2-gpu]>
  <Module test_elastic_inference.py>
    <Function test_elastic_inference[py2-gpu]>
  <Module test_hosting.py>
    <Function test_hosting[py2-gpu]>
<Module test/integration/local/test_default_model_fn.py>
  <Function test_default_model_fn[py3-cpu]>
  <Function test_default_model_fn_content_type[py3-cpu]>
<Module test/integration/local/test_gluon_hosting.py>
  <Function test_gluon_hosting[py3-cpu]>
<Module test/integration/local/test_hosting.py>
  <Function test_hosting[py3-cpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_import[py3-cpu]>
<Package ~/Documents/workspace/sagemaker-mxnet-serving-container/test/integration/sagemaker>
  <Module test_batch_transform.py>
    <Function test_batch_transform[py3-cpu]>
  <Module test_elastic_inference.py>
    <Function test_elastic_inference[py3-cpu]>
  <Module test_hosting.py>
    <Function test_hosting[py3-cpu]>
<Module test/integration/local/test_default_model_fn.py>
  <Function test_default_model_fn[py3-gpu]>
  <Function test_default_model_fn_content_type[py3-gpu]>
<Module test/integration/local/test_gluon_hosting.py>
  <Function test_gluon_hosting[py3-gpu]>
<Module test/integration/local/test_hosting.py>
  <Function test_hosting[py3-gpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_import[py3-gpu]>
<Package ~/Documents/workspace/sagemaker-mxnet-serving-container/test/integration/sagemaker>
  <Module test_batch_transform.py>
    <Function test_batch_transform[py3-gpu]>
  <Module test_elastic_inference.py>
    <Function test_elastic_inference[py3-gpu]>
  <Module test_hosting.py>
    <Function test_hosting[py3-gpu]>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
