### PR TITLE
change: update tests to handle pytest's ExceptionInfo change

### DIFF
--- a/test/unit/test_default_inference_handler.py
+++ b/test/unit/test_default_inference_handler.py
@@ -132,7 +132,7 @@ def test_mxnet_default_input_fn_with_accelerator(decode, mx_ndarray, mx_eia):
 def test_mxnet_default_input_fn_invalid_content_type():
     with pytest.raises(errors.UnsupportedFormatError) as e:
         DefaultMXNetInferenceHandler().default_input_fn(None, 'bad/content-type')
-    assert 'Content type bad/content-type is not supported by this framework' in str(e)
+    e.match('Content type bad/content-type is not supported by this framework')
 
 
 @patch('sagemaker_inference.encoder.encode', return_value=str())
@@ -151,7 +151,7 @@ def test_mxnet_default_output_fn(encode):
 def test_mxnet_default_output_fn_invalid_content_type():
     with pytest.raises(errors.UnsupportedFormatError) as e:
         DefaultMXNetInferenceHandler().default_output_fn(None, 'bad/content-type')
-    assert 'Content type bad/content-type is not supported by this framework' in str(e)
+    e.match('Content type bad/content-type is not supported by this framework')
 
 
 #################################################################################
@@ -231,7 +231,7 @@ def test_module_default_input_fn_with_accelerator(decode, mx_ndarray_iter, mx_nd
 def test_module_default_input_fn_invalid_content_type():
     with pytest.raises(errors.UnsupportedFormatError) as e:
         DefaultModuleInferenceHandler().default_input_fn(None, 'bad/content-type')
-    assert 'Content type bad/content-type is not supported by this framework' in str(e)
+    e.match('Content type bad/content-type is not supported by this framework')
 
 
 def test_module_default_predict_fn():

--- a/test/unit/test_handler_service.py
+++ b/test/unit/test_handler_service.py
@@ -90,4 +90,4 @@ def test_user_module_unsupported(import_module, env):
         HandlerService._user_module_transformer()
 
     import_module.assert_called_once_with(MODULE_NAME)
-    assert 'Unsupported model type' in str(e)
+    e.match('Unsupported model type')


### PR DESCRIPTION
*Description of changes:*
pytest returns [`ExceptionInfo` objects](https://docs.pytest.org/en/latest/reference.html#exceptioninfo) instead of the exception itself. pytest 5.0.0 makes those objects respond differently to `str()`, which causes the unit tests to fail with something like:

```
>       assert 'Unsupported model type' in str(e)
E       AssertionError: assert 'Unsupported model type' in '<ExceptionInfo ValueError tblen=2>'
E        +  where '<ExceptionInfo ValueError tblen=2>' = str(<ExceptionInfo ValueError tblen=2>)
```

this is documented in their changelog at https://docs.pytest.org/en/latest/changelog.html:
> #5412: ExceptionInfo objects (returned by pytest.raises) now have the same str representation as repr, which avoids some confusion when users use print(e) to inspect the object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
