### PR TITLE
change: remove unnecessary pytest marks

### DIFF
--- a/test/integration/sagemaker/test_elastic_inference.py
+++ b/test/integration/sagemaker/test_elastic_inference.py
@@ -38,8 +38,6 @@ def skip_if_non_supported_ei_region(region):
         pytest.skip('EI is not supported in {}'.format(region))
 
 
-@pytest.mark.skip_if_non_supported_ei_region
-@pytest.mark.skip_if_no_accelerator
 def test_elastic_inference(ecr_image, sagemaker_session, instance_type, accelerator_type, framework_version):
     endpoint_name = utils.unique_name_from_base('test-mxnet-ei')
 


### PR DESCRIPTION
*Description of changes:*
pytest is spitting out warnings for unregistered marks. I started to register them, but then realized the fixtures are automatically used, so then just tried removing the marks entirely, and things seem to work the same.

*Testing done:*
```
$ pytest -rsx test/integration/sagemaker/test_elastic_inference.py
===== test session starts =====
[...]
collected 1 item

test/integration/sagemaker/test_elastic_inference.py::test_elastic_inference[py3-cpu] SKIPPED          [100%]

===== short test summary info =====
SKIPPED [1] /Users/laurenyu/Documents/workspace/sagemaker-mxnet-serving-container/test/integration/sagemaker/test_elastic_inference.py:33: Skipping because accelerator type was not provided
===== 1 skipped in 0.15 seconds =====

$ pytest -rsx test/integration/sagemaker/test_elastic_inference.py --region foo --accelerator-type ml.eia1.medium
===== test session starts =====
[...]
collected 1 item

test/integration/sagemaker/test_elastic_inference.py::test_elastic_inference[py3-cpu] SKIPPED          [100%]

===== short test summary info =====
SKIPPED [1] /Users/laurenyu/Documents/workspace/sagemaker-mxnet-serving-container/test/integration/sagemaker/test_elastic_inference.py:39: EI is not supported in foo
===== 1 skipped in 0.14 seconds =====
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
