### PR TITLE
change: configure flake8 to ignore the docker/ directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ exclude =
     .tox
     test/resources
     venv/
+    docker/
 max-complexity = 10
 ignore =
     FI10,


### PR DESCRIPTION
*Description of changes:*
flake8 wasn't really checking docker/ before either, but now there's a Python file in there, so we do need to explicitly configure flake8 to not check the docker/ directory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
