### PR TITLE
change: use Python 2 build logic for EI images during release

### DIFF
--- a/scripts/build_all.py
+++ b/scripts/build_all.py
@@ -31,7 +31,7 @@ def _parse_args():
 
 
 def _build_image(build_dir, arch, prev_image_uri, py_version):
-    if py_version == '2.7':
+    if py_version == '2.7' or arch == 'eia':
         dockerfile = os.path.join(build_dir, 'Dockerfile.{}'.format(arch))
 
         build_cmd = [


### PR DESCRIPTION
*Description of changes:*
this is a fix for the change in #38 where the EI images are also built according to our old logic. tested the buildspec through local CPU tests in my personal AWS account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
