### PR TITLE
Skipping EIA test if accelerator type is None.

### DIFF
--- a/test/integration/sagemaker/test_elastic_inference.py
+++ b/test/integration/sagemaker/test_elastic_inference.py
@@ -38,8 +38,6 @@ def skip_if_non_supported_ei_region(region):
         pytest.skip('EI is not supported in {}'.format(region))
 
 
-@pytest.mark.skip_if_non_supported_ei_region
-@pytest.mark.skip_if_no_accelerator
 def test_elastic_inference(ecr_image, sagemaker_session, instance_type, accelerator_type, framework_version):
     endpoint_name = utils.unique_name_from_base('test-mxnet-ei')
 

--- a/test/integration/sagemaker/test_elastic_inference.py
+++ b/test/integration/sagemaker/test_elastic_inference.py
@@ -39,7 +39,6 @@ def skip_if_non_supported_ei_region(region):
 
 @pytest.mark.skip_if_non_supported_ei_region()
 @pytest.mark.skip_if_no_accelerator()
-
 def test_elastic_inference(ecr_image, sagemaker_session, instance_type, accelerator_type, framework_version):
     endpoint_name = utils.unique_name_from_base('test-mxnet-ei')
 


### PR DESCRIPTION
*Issue #, if available:*
The function for skip EIA test is written but it is not been used.
Without these two lines , The Sagemaker 2nd test(test_elastic_inference.py), when used for CPU does not skip with accelerator option given as none.

*Description of changes:*
After the inclusion of these two lines, the codebase of DLC will be shorter.

Have tested it on CPU and EIA instance after making the change in my fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
