### PR TITLE
Update the build instructions to match reality.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Before building these images, you need to have the pip-installable binary of thi
 
 For the Python 2 and EI images, this binary should remain in ``dist/``.
 For the Python 3 CPU and GPU images, this binary should be copied to ``docker/<framework_version>/py3``.
-In both cases, the binary should be renamed to ``sagemaker-mxnet-serving-container.tar.gz``.
+In both cases, the binary should be renamed to ``sagemaker_mxnet_serving_container.tar.gz``.
 
 Once you have created this binary, you can then build the image.
 The integration tests expect the Docker images to be tagged as ``preprod-mxnet-serving:<tag>``, where ``<tag>`` looks like <mxnet_version>-<processor>-<python_version> (e.g. 1.4.1-cpu-py3).
@@ -63,12 +63,12 @@ Example commands for building images:
     # All build instructions assume you're starting from this repository's root directory.
 
     # MXNet 1.4.1, Python 3, CPU
-    $ cp dist/sagemaker-mxnet-container-*.tar.gz docker/1.4.1/py3/.
+    $ cp dist/sagemaker_mxnet_serving_container-*.tar.gz docker/1.4.1/py3/sagemaker_mxnet_serving_container.tar.gz
     $ cd docker/1.4.1/py3
     $ docker build -t preprod-mxnet-serving:1.4.1-cpu-py3 -f Dockerfile.cpu .
 
     # MXNet 1.4.1, Python 2, GPU
-    $ cp dist/sagemaker-mxnet-container-*.tar.gz dist/sagemaker-mxnet-container.tar.gz
+    $ cp dist/sagemaker_mxnet_serving_container-*.tar.gz dist/sagemaker_mxnet_serving_container.tar.gz
     $ docker build -t preprod-mxnet-serving:1.4.1-gpu-py2 -f docker/1.4.1/py2/Dockerfile.gpu .
 
 Don't forget the period at the end of the command!
@@ -102,7 +102,7 @@ Example:
 ::
 
     # MXNet 1.4.1, Python 3, EI
-    $ cp dist/sagemaker-mxnet-container-*.tar.gz dist/sagemaker-mxnet-container.tar.gz
+    $ cp dist/sagemaker_mxnet_serving_container-*.tar.gz dist/sagemaker_mxnet_serving_container.tar.gz
     $ docker build -t preprod-mxnet-serving-eia:1.4.1-cpu-py3 -f docker/1.4.1/py3/Dockerfile.eia .
 
 


### PR DESCRIPTION
File dist/sagemaker-mxnet-serving-container-*.tar.gz is actually generated as and expected to be: dist/sagemaker_mxnet_serving_container-*.tar.gz

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
