### PR TITLE
Resolve pip issue in docker build for EIA

### DIFF
--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -8,7 +8,7 @@ ARG MMS_VERSION=1.0.5
 ARG PYTHON=python3
 ARG PIP=pip3
 ARG PYTHON_VERSION=3.6.8
-ARG HEALTH_CHECK_VERSION=1.3.2
+ARG HEALTH_CHECK_VERSION=1.3.3
 
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -64,6 +64,7 @@ COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container
 RUN pip install --no-cache-dir --upgrade \
     pip \
     setuptools \
+ && pip install --no-cache-dir \
     https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
@@ -74,8 +75,9 @@ RUN pip install --no-cache-dir --upgrade \
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
 # TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?
-RUN ln -s /dev/null /dev/raw1394 \
- && useradd -m model-server \
+RUN ln -s /dev/null /dev/raw1394
+
+RUN useradd -m model-server \
  && mkdir -p /home/model-server/tmp \
  && chown -R model-server /home/model-server
 

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -6,12 +6,11 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG MMS_VERSION=1.0.5
 ARG PYTHON=python3
-ARG PIP=pip3
 ARG PYTHON_VERSION=3.6.8
 ARG HEALTH_CHECK_VERSION=1.3.3
 
-RUN apt-get update && \
-    apt-get -y install --no-install-recommends \
+RUN apt-get update \
+ && apt-get -y install --no-install-recommends \
     build-essential \
     ca-certificates \
     curl \
@@ -21,53 +20,64 @@ RUN apt-get update && \
     vim \
     wget \
     zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
 # See http://bugs.python.org/issue19846
-ENV LANG C.UTF-8
+ENV LANG C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
+    PYTHONIOENCODING=UTF-8 \
+    LC_ALL=C.UTF-8
 
-RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz && \
-    tar -xvf Python-$PYTHON_VERSION.tgz && cd Python-$PYTHON_VERSION && \
-    ./configure && make && make install && \
-    apt-get update && apt-get install -y --no-install-recommends libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev && \
-    make && make install && rm -rf ../Python-$PYTHON_VERSION* && \
-    ln -s /usr/local/bin/pip3 /usr/bin/pip
-
-RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
-
-RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
+RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz \
+ && tar -xvf Python-$PYTHON_VERSION.tgz \
+ && cd Python-$PYTHON_VERSION \
+ && ./configure \
+ && make \
+ && make install \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+    libreadline-gplv2-dev \
+    libncursesw5-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    tk-dev \
+    libgdbm-dev \
+    libc6-dev \
+    libbz2-dev \
+ && make \
+ && make install \
+ && rm -rf ../Python-$PYTHON_VERSION* \
+ && ln -s /usr/local/bin/pip3 /usr/bin/pip \
+ && ln -s $(which ${PYTHON}) /usr/local/bin/python
 
 WORKDIR /
 
 RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -O /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
-    && tar -xvf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -C /opt/ \
-    && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz
-RUN chmod a+x /opt/ei_health_check/bin/health_check
+ && tar -xvf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -C /opt/ \
+ && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
+ && chmod a+x /opt/ei_health_check/bin/health_check
 
 COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
 
-RUN ${PIP} install --no-cache-dir https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl  \
-                                  mxnet-model-server==$MMS_VERSION \
-                                  keras-mxnet==2.2.4.1 \
-                                  onnx==1.4.1 \
-                                  /sagemaker_mxnet_serving_container.tar.gz && \
-    rm /sagemaker_mxnet_serving_container.tar.gz
+RUN pip install --no-cache-dir --upgrade \
+    pip \
+    setuptools \
+    https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
+    mxnet-model-server==$MMS_VERSION \
+    keras-mxnet==2.2.4.1 \
+    onnx==1.4.1 \
+    /sagemaker_mxnet_serving_container.tar.gz \
+ && rm /sagemaker_mxnet_serving_container.tar.gz
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
 # TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?
-RUN ln -s /dev/null /dev/raw1394
-
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
-    PYTHONIOENCODING=UTF-8 \
-    LANG=C.UTF-8 \
-    LC_ALL=C.UTF-8
-
-RUN useradd -m model-server \
-    && mkdir -p /home/model-server/tmp \
-    && chown -R model-server /home/model-server
+RUN ln -s /dev/null /dev/raw1394 \
+ && useradd -m model-server \
+ && mkdir -p /home/model-server/tmp \
+ && chown -R model-server /home/model-server
 
 COPY mms-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
 COPY config.properties /home/model-server

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -1,23 +1,57 @@
-FROM awsdeeplearningteam/mxnet-model-server:base-cpu-py3.6
+FROM ubuntu:16.04
+
+LABEL maintainer="Amazon AI"
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
+ARG MMS_VERSION=1.0.5
+ARG PYTHON=python3
+ARG PYTHON_PIP=python3-pip
+ARG PIP=pip3
+ARG PYTHON_VERSION=3.6.8
+
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
-    libopencv-dev \
     build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libopencv-dev \
+    openjdk-8-jdk-headless \
+    vim \
+    wget \
+    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
+RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz && \
+    tar -xvf Python-$PYTHON_VERSION.tgz && cd Python-$PYTHON_VERSION && \
+    ./configure && make && make install && \
+    apt-get update && apt-get install -y --no-install-recommends libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev && \
+    make && make install && rm -rf ../Python-$PYTHON_VERSION* && \
+    ln -s /usr/local/bin/pip3 /usr/bin/pip
+
+RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
+
+RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
 
 WORKDIR /
 
-COPY dist/sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
+RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v1.3.2/ei_health_check_1.3.2.tar.gz -O /opt/ei_health_check_1.3.2.tar.gz \
+    && tar -xvf /opt/ei_health_check_1.3.2.tar.gz -C /opt/ \
+    && rm -rf /opt/ei_health_check_1.3.2.tar.gz
+RUN chmod a+x /opt/ei_health_check/bin/health_check
 
-RUN pip install --no-cache https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
-                           keras-mxnet==2.2.4.1 \
-                           numpy==1.14.5 \
-                           onnx==1.4.1 \
-                           /sagemaker_mxnet_serving_container.tar.gz && \
-    rm /sagemaker_mxnet_serving_container.tar.gz
+COPY sagemaker_mxnet_serving_container-1.1.3.tar.gz /sagemaker_mxnet_serving_container-1.1.3.tar.gz
+
+RUN ${PIP} install --no-cache-dir https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl  \
+                                  mxnet-model-server==$MMS_VERSION \
+                                  keras-mxnet==2.2.4.1 \
+                                  onnx==1.4.1 \
+                                  /sagemaker_mxnet_serving_container-1.1.3.tar.gz && \
+    rm /sagemaker_mxnet_serving_container-1.1.3.tar.gz
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
@@ -31,4 +65,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-ENTRYPOINT []
+RUN useradd -m model-server \
+    && mkdir -p /home/model-server/tmp \
+    && chown -R model-server /home/model-server
+
+COPY mms-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
+COPY config.properties /home/model-server
+
+RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
+
+EXPOSE 8080 8081
+ENV TEMP=/home/model-server/tmp
+ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
+CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -63,8 +63,9 @@ COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container
 
 RUN pip install --no-cache-dir --upgrade \
     pip \
-    setuptools \
- && pip install --no-cache-dir \
+    setuptools
+
+RUN pip install --no-cache-dir \
     https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -23,7 +23,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # See http://bugs.python.org/issue19846
-ENV LANG C.UTF-8 \
+ENV LANG=C.UTF-8 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -6,9 +6,9 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG MMS_VERSION=1.0.5
 ARG PYTHON=python3
-ARG PYTHON_PIP=python3-pip
 ARG PIP=pip3
 ARG PYTHON_VERSION=3.6.8
+ARG HEALTH_CHECK_VERSION=1.3.2
 
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
@@ -39,19 +39,19 @@ RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
 
 WORKDIR /
 
-RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v1.3.2/ei_health_check_1.3.2.tar.gz -O /opt/ei_health_check_1.3.2.tar.gz \
-    && tar -xvf /opt/ei_health_check_1.3.2.tar.gz -C /opt/ \
-    && rm -rf /opt/ei_health_check_1.3.2.tar.gz
+RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -O /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
+    && tar -xvf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -C /opt/ \
+    && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz
 RUN chmod a+x /opt/ei_health_check/bin/health_check
 
-COPY sagemaker_mxnet_serving_container-1.1.3.tar.gz /sagemaker_mxnet_serving_container-1.1.3.tar.gz
+COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
 
 RUN ${PIP} install --no-cache-dir https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl  \
                                   mxnet-model-server==$MMS_VERSION \
                                   keras-mxnet==2.2.4.1 \
                                   onnx==1.4.1 \
-                                  /sagemaker_mxnet_serving_container-1.1.3.tar.gz && \
-    rm /sagemaker_mxnet_serving_container-1.1.3.tar.gz
+                                  /sagemaker_mxnet_serving_container.tar.gz && \
+    rm /sagemaker_mxnet_serving_container.tar.gz
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/docker/1.4.1/py3/mms-entrypoint.py
+++ b/docker/1.4.1/py3/mms-entrypoint.py
@@ -1,3 +1,16 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import shlex
 import subprocess
 import sys


### PR DESCRIPTION
Issue: Building eia dockerfile caused pip error:
```
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    from pip import main
ImportError: cannot import name main
```
Fix:
- Merging pip upgrade and pip install into a single RUN statement caused pip to not be found.
- Fixed by splitting statement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
