### PR TITLE
Resolve pip issue in docker build for EIA py2

### DIFF
--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -6,8 +6,8 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG MMS_VERSION=1.0.5
 ARG PYTHON=python
-ARG PYTHON_PIP=python-pip
 ARG PIP=pip
+ARG HEALTH_CHECK_VERSION=1.3.2
 
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
@@ -33,19 +33,19 @@ RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
 
 WORKDIR /
 
-RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v1.3.2/ei_health_check_1.3.2.tar.gz -O /opt/ei_health_check_1.3.2.tar.gz \
-    && tar -xvf /opt/ei_health_check_1.3.2.tar.gz -C /opt/ \
-    && rm -rf /opt/ei_health_check_1.3.2.tar.gz
+RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -O /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
+    && tar -xvf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -C /opt/ \
+    && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz
 RUN chmod a+x /opt/ei_health_check/bin/health_check
 
-COPY sagemaker_mxnet_serving_container-1.1.3.tar.gz /sagemaker_mxnet_serving_container-1.1.3.tar.gz
+COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
 
 RUN ${PIP} install --no-cache-dir https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl  \
                                   mxnet-model-server==$MMS_VERSION \
                                   keras-mxnet==2.2.4.1 \
                                   onnx==1.4.1 \
-                                  /sagemaker_mxnet_serving_container-1.1.3.tar.gz && \
-    rm /sagemaker_mxnet_serving_container-1.1.3.tar.gz
+                                  /sagemaker_mxnet_serving_container.tar.gz && \
+    rm /sagemaker_mxnet_serving_container.tar.gz
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -42,8 +42,9 @@ COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container
 
 RUN pip install --no-cache-dir --upgrade \
     pip \
-    setuptools \
- && pip install --no-cache-dir \
+    setuptools
+
+RUN pip install --no-cache-dir \
     https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \

--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -31,8 +31,6 @@ ENV LANG=C.UTF-8 \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=C.UTF-8
 
-RUN pip --no-cache-dir install --upgrade pip setuptools
-
 WORKDIR /
 
 RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -O /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
@@ -42,8 +40,11 @@ RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/
 
 COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
 
-RUN pip install --no-cache-dir \
-    https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl  \
+RUN pip install --no-cache-dir --upgrade \
+    pip \
+    setuptools \
+ && pip install --no-cache-dir \
+    https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     onnx==1.4.1 \

--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -7,7 +7,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 ARG MMS_VERSION=1.0.5
 ARG PYTHON=python
 ARG PIP=pip
-ARG HEALTH_CHECK_VERSION=1.3.2
+ARG HEALTH_CHECK_VERSION=1.3.3
 
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \

--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -6,7 +6,6 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG MMS_VERSION=1.0.5
 ARG PYTHON=python
-ARG PIP=pip
 ARG HEALTH_CHECK_VERSION=1.3.3
 
 RUN apt-get update && \
@@ -17,51 +16,47 @@ RUN apt-get update && \
     git \
     libopencv-dev \
     openjdk-8-jdk-headless \
+    python-dev \
+    python-pip \
     vim \
     wget \
     zlib1g-dev \
-    python-dev \
-    python-pip \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
 # See http://bugs.python.org/issue19846
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
+    PYTHONIOENCODING=UTF-8 \
+    LC_ALL=C.UTF-8
 
-RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
-
-RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
+RUN pip --no-cache-dir install --upgrade pip setuptools
 
 WORKDIR /
 
 RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -O /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
-    && tar -xvf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -C /opt/ \
-    && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz
-RUN chmod a+x /opt/ei_health_check/bin/health_check
+ && tar -xvf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz -C /opt/ \
+ && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
+ && chmod a+x /opt/ei_health_check/bin/health_check
 
 COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
 
-RUN ${PIP} install --no-cache-dir https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl  \
-                                  mxnet-model-server==$MMS_VERSION \
-                                  keras-mxnet==2.2.4.1 \
-                                  onnx==1.4.1 \
-                                  /sagemaker_mxnet_serving_container.tar.gz && \
-    rm /sagemaker_mxnet_serving_container.tar.gz
+RUN pip install --no-cache-dir \
+    https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl  \
+    mxnet-model-server==$MMS_VERSION \
+    keras-mxnet==2.2.4.1 \
+    onnx==1.4.1 \
+    /sagemaker_mxnet_serving_container.tar.gz \
+ && rm /sagemaker_mxnet_serving_container.tar.gz
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
 # TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?
-RUN ln -s /dev/null /dev/raw1394
-
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
-    PYTHONIOENCODING=UTF-8 \
-    LANG=C.UTF-8 \
-    LC_ALL=C.UTF-8
-
-RUN useradd -m model-server \
-    && mkdir -p /home/model-server/tmp \
-    && chown -R model-server /home/model-server
+RUN ln -s /dev/null /dev/raw1394 \
+ && useradd -m model-server \
+ && mkdir -p /home/model-server/tmp \
+ && chown -R model-server /home/model-server
 
 COPY mms-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
 COPY config.properties /home/model-server

--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -53,8 +53,9 @@ RUN pip install --no-cache-dir \
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
 # TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?
-RUN ln -s /dev/null /dev/raw1394 \
- && useradd -m model-server \
+RUN ln -s /dev/null /dev/raw1394
+
+RUN useradd -m model-server \
  && mkdir -p /home/model-server/tmp \
  && chown -R model-server /home/model-server
 

--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -1,22 +1,51 @@
-FROM awsdeeplearningteam/mxnet-model-server:base-cpu-py2.7
+FROM ubuntu:16.04
+
+LABEL maintainer="Amazon AI"
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
+ARG MMS_VERSION=1.0.5
+ARG PYTHON=python
+ARG PYTHON_PIP=python-pip
+ARG PIP=pip
+
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
-    libopencv-dev \
     build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libopencv-dev \
+    openjdk-8-jdk-headless \
+    vim \
+    wget \
+    zlib1g-dev \
+    python-dev \
+    python-pip \
     && rm -rf /var/lib/apt/lists/*
+
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
+RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
+
+RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
 
 WORKDIR /
 
-COPY dist/sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
+RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v1.3.2/ei_health_check_1.3.2.tar.gz -O /opt/ei_health_check_1.3.2.tar.gz \
+    && tar -xvf /opt/ei_health_check_1.3.2.tar.gz -C /opt/ \
+    && rm -rf /opt/ei_health_check_1.3.2.tar.gz
+RUN chmod a+x /opt/ei_health_check/bin/health_check
 
-RUN pip install --no-cache https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
-                           keras-mxnet==2.2.4.1 \
-                           onnx==1.4.1 \
-                           /sagemaker_mxnet_serving_container.tar.gz && \
-    rm /sagemaker_mxnet_serving_container.tar.gz
+COPY sagemaker_mxnet_serving_container-1.1.3.tar.gz /sagemaker_mxnet_serving_container-1.1.3.tar.gz
+
+RUN ${PIP} install --no-cache-dir https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl  \
+                                  mxnet-model-server==$MMS_VERSION \
+                                  keras-mxnet==2.2.4.1 \
+                                  onnx==1.4.1 \
+                                  /sagemaker_mxnet_serving_container-1.1.3.tar.gz && \
+    rm /sagemaker_mxnet_serving_container-1.1.3.tar.gz
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
@@ -30,4 +59,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-ENTRYPOINT []
+RUN useradd -m model-server \
+    && mkdir -p /home/model-server/tmp \
+    && chown -R model-server /home/model-server
+
+COPY mms-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
+COPY config.properties /home/model-server
+
+RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
+
+EXPOSE 8080 8081
+ENV TEMP=/home/model-server/tmp
+ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
+CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.4.1/py2/dockerd-entrypoint.sh
+++ b/docker/1.4.1/py2/dockerd-entrypoint.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 set -e
 
 if [[ "$1" = "serve" ]]; then

--- a/docker/1.4.1/py2/mms-entrypoint.py
+++ b/docker/1.4.1/py2/mms-entrypoint.py
@@ -1,0 +1,13 @@
+import shlex
+import subprocess
+import sys
+
+from sagemaker_mxnet_serving_container import serving
+
+if sys.argv[1] == 'serve':
+    serving.main()
+else:
+    subprocess.check_call(shlex.split(' '.join(sys.argv[1:])))
+
+# prevent docker exit
+subprocess.call(['tail', '-f', '/dev/null'])

--- a/docker/1.4.1/py2/mms-entrypoint.py
+++ b/docker/1.4.1/py2/mms-entrypoint.py
@@ -1,3 +1,15 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 import shlex
 import subprocess
 import sys


### PR DESCRIPTION
Issue: Building eia dockerfile caused pip error:
```
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    from pip import main
ImportError: cannot import name main
```
Fix:
- Merging pip upgrade and pip install into a single RUN statement caused pip to not be found.
- Fixed by splitting statement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.