### PR TITLE
separate pip upgrade from other installs

### DIFF
--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -42,8 +42,9 @@ COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container
 
 RUN pip install --no-cache-dir --upgrade \
     pip \
-    setuptools \
- && pip install --no-cache-dir \
+    setuptools
+
+RUN pip install --no-cache-dir \
     https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -63,8 +63,9 @@ COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container
 
 RUN pip install --no-cache-dir --upgrade \
     pip \
-    setuptools \
- && pip install --no-cache-dir \
+    setuptools
+
+RUN pip install --no-cache-dir \
     https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.1-py2.py3-none-manylinux1_x86_64.whl \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \


### PR DESCRIPTION
Issue: Building eia dockerfile caused pip error:
```
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    from pip import main
ImportError: cannot import name main
```
Fix:
- Merging pip upgrade and pip install into a single RUN statement caused pip to not be found.
- Fixed by splitting statement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.