### PR TITLE
Update build context on 1.4.1 EI dockerfiles

### DIFF
--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -38,9 +38,7 @@ RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/
  && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
  && chmod a+x /opt/ei_health_check/bin/health_check
 
-COPY dist /dist
-
-RUN mv /dist/sagemaker_mxnet_serving_container*.tar.gz /dist/sagemaker_mxnet_serving_container.tar.gz
+COPY dist/sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
 
 RUN pip install --no-cache-dir --upgrade \
     pip \
@@ -51,8 +49,8 @@ RUN pip install --no-cache-dir \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     onnx==1.4.1 \
-    /dist/sagemaker_mxnet_serving_container.tar.gz \
- && rm -rf /dist
+    /sagemaker_mxnet_serving_container.tar.gz \
+ && rm /sagemaker_mxnet_serving_container.tar.gz
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/docker/1.4.1/py2/Dockerfile.eia
+++ b/docker/1.4.1/py2/Dockerfile.eia
@@ -8,8 +8,8 @@ ARG MMS_VERSION=1.0.5
 ARG PYTHON=python
 ARG HEALTH_CHECK_VERSION=1.3.3
 
-RUN apt-get update && \
-    apt-get -y install --no-install-recommends \
+RUN apt-get update \
+ && apt-get -y install --no-install-recommends \
     build-essential \
     ca-certificates \
     curl \
@@ -38,7 +38,9 @@ RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/
  && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
  && chmod a+x /opt/ei_health_check/bin/health_check
 
-COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
+COPY dist /dist
+
+RUN mv /dist/sagemaker_mxnet_serving_container*.tar.gz /dist/sagemaker_mxnet_serving_container.tar.gz
 
 RUN pip install --no-cache-dir --upgrade \
     pip \
@@ -49,8 +51,8 @@ RUN pip install --no-cache-dir \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     onnx==1.4.1 \
-    /sagemaker_mxnet_serving_container.tar.gz \
- && rm /sagemaker_mxnet_serving_container.tar.gz
+    /dist/sagemaker_mxnet_serving_container.tar.gz \
+ && rm -rf /dist
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -38,14 +38,15 @@ RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSIO
  && make install \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-    libreadline-gplv2-dev \
-    libncursesw5-dev \
-    libssl-dev \
-    libsqlite3-dev \
-    tk-dev \
-    libgdbm-dev \
-    libc6-dev \
     libbz2-dev \
+    libc6-dev \
+    libgdbm-dev \
+    libncursesw5-dev \
+    libreadline-gplv2-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    tk-dev \
+ && rm -rf /var/lib/apt/lists/* \
  && make \
  && make install \
  && rm -rf ../Python-$PYTHON_VERSION* \
@@ -59,9 +60,7 @@ RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/
  && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
  && chmod a+x /opt/ei_health_check/bin/health_check
 
-COPY dist /dist
-
-RUN mv /dist/sagemaker_mxnet_serving_container*.tar.gz /dist/sagemaker_mxnet_serving_container.tar.gz
+COPY dist/sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
 
 RUN pip install --no-cache-dir --upgrade \
     pip \
@@ -72,8 +71,8 @@ RUN pip install --no-cache-dir \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     onnx==1.4.1 \
-    /dist/sagemaker_mxnet_serving_container.tar.gz \
- && rm -rf /dist
+    /sagemaker_mxnet_serving_container.tar.gz \
+ && rm /sagemaker_mxnet_serving_container.tar.gz
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/docker/1.4.1/py3/Dockerfile.eia
+++ b/docker/1.4.1/py3/Dockerfile.eia
@@ -59,7 +59,9 @@ RUN wget https://amazonei-healthcheck.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/
  && rm -rf /opt/ei_health_check_${HEALTH_CHECK_VERSION}.tar.gz \
  && chmod a+x /opt/ei_health_check/bin/health_check
 
-COPY sagemaker_mxnet_serving_container.tar.gz /sagemaker_mxnet_serving_container.tar.gz
+COPY dist /dist
+
+RUN mv /dist/sagemaker_mxnet_serving_container*.tar.gz /dist/sagemaker_mxnet_serving_container.tar.gz
 
 RUN pip install --no-cache-dir --upgrade \
     pip \
@@ -70,8 +72,8 @@ RUN pip install --no-cache-dir \
     mxnet-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.1 \
     onnx==1.4.1 \
-    /sagemaker_mxnet_serving_container.tar.gz \
- && rm /sagemaker_mxnet_serving_container.tar.gz
+    /dist/sagemaker_mxnet_serving_container.tar.gz \
+ && rm -rf /dist
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394


### PR DESCRIPTION
**Issue**
- Build for EIA dockerfiles failed due to different expected build context.

**Fix**
- Modify expected build context w.r.t. sagemaker-mxnet-serving-container distribution, to match existing build instructions on README.
- Also cleaned up Dockerfiles according to Docker best practices.

**Tests**
- Tested images built from these dockerfiles on an EC2 instance with Elastic Inference to serve a model as per instructions at https://docs.aws.amazon.com/elastic-inference/latest/developerguide/ei-dlc-ec2-mxnet.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
