### PR TITLE
fix: build context in release build

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -34,6 +34,7 @@ phases:
       - python3 setup.py sdist
       - mv dist/sagemaker_mxnet_serving_container-*.tar.gz dist/sagemaker_mxnet_serving_container.tar.gz
       - cp dist/sagemaker_mxnet_serving_container.tar.gz docker/$FRAMEWORK_FULL_VERSION/py3/sagemaker_mxnet_serving_container.tar.gz
+      - cp dist/sagemaker_mxnet_serving_container.tar.gz docker/$FRAMEWORK_FULL_VERSION/py2/sagemaker_mxnet_serving_container.tar.gz
 
       # build images
       - python3 scripts/build_all.py --version $FRAMEWORK_FULL_VERSION --account $ACCOUNT --repo $ECR_REPO


### PR DESCRIPTION
*Issue #, if available:*
release build cannot find the tar file in py2 build context

*Description of changes:*
copy tar file to docker/py3 and docker/py2 dirs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
