### PR TITLE
Revert "change: install python-dateutil explicitly for botocore (#81)"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,9 +46,7 @@ passenv =
     AWS_DEFAULT_REGION
 # {posargs} can be passed in by additional arguments specified when invoking tox.
 # Can be used to specify which tests to run, e.g.: tox -- -s
-# TODO: Remove pip install python-dateutil==2.8.0 once botocore no longer requires a pinned version
 commands =
-    pip install python-dateutil==2.8.0
     coverage run --rcfile .coveragerc_{envname} --source sagemaker_mxnet_serving_container -m pytest {posargs}
     {env:IGNORE_COVERAGE:} coverage report --fail-under=90 --include *sagemaker_mxnet_serving_container*
 deps = .[test]


### PR DESCRIPTION
This reverts commit e7fa17b524bb8aabffc541b52a1d5fe95600c200.

*Issue #, if available:*

*Description of changes:*
Same thing as https://github.com/aws/sagemaker-python-sdk/pull/1229

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
