### PR TITLE
change: Modify HandlerService to use context model_dir

### DIFF
--- a/src/sagemaker_mxnet_serving_container/handler_service.py
+++ b/src/sagemaker_mxnet_serving_container/handler_service.py
@@ -40,7 +40,7 @@ class HandlerService(DefaultHandlerService):
         self._service = None
 
     @staticmethod
-    def _user_module_transformer(model_dir):
+    def _user_module_transformer(model_dir=environment.model_dir):
         user_module = importlib.import_module(environment.Environment().module_name)
 
         if hasattr(user_module, 'transform_fn'):

--- a/test/unit/test_handler_service.py
+++ b/test/unit/test_handler_service.py
@@ -27,10 +27,14 @@ MODULE_NAME = 'module_name'
 
 
 @patch('sagemaker_mxnet_serving_container.handler_service.HandlerService._user_module_transformer')
-def test_handler_service(user_module_transformer):
+@patch('sagemaker_inference.default_handler_service.DefaultHandlerService.initialize')
+def test_handler_service(user_module_transformer, initialize):
     service = HandlerService()
 
-    assert service._service == user_module_transformer()
+    context = Mock()
+    service.initialize(context)
+
+    assert isinstance(service._service, Mock)
 
 
 class UserModuleTransformFn:


### PR DESCRIPTION
*Description of changes:*
This change modifies the HandlerService to use the `model_dir` from the request context instead of from `sagemaker_inference.environment.model_dir`. This is necessary to support the use of models in different directories but using the default inference handler: https://github.com/aws/sagemaker-inference-toolkit/pull/42


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
