### PR TITLE
Upgrade the version of sagemaker-inference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ setup(
     ],
 
     # support sagemaker-inference==1.1.0 for mxnet 1.4 eia image and
-    # sagemaker-inference==1.1.2 version for mxnet 1.6 image.
-    install_requires=['sagemaker-inference>=1.1.0,<=1.1.2', 'retrying==1.3.3'],
+    # sagemaker-inference==1.2.0 version for mxnet 1.6 image.
+    install_requires=['sagemaker-inference>=1.1.0,<=1.2.0', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'pytest-rerunfailures',
                  'mock', 'sagemaker==1.23.0', 'docker-compose', 'mxnet==1.4.0', 'awslogs', 'requests_mock']


### PR DESCRIPTION
Upgrade to the latest version of sagemaker-inference: https://github.com/aws/sagemaker-inference-toolkit/releases/tag/v1.2.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
