### PR TITLE
feature: Python 3.7 support

### DIFF
--- a/.coveragerc_py37
+++ b/.coveragerc_py37
@@ -1,0 +1,20 @@
+[run]
+branch = True
+timid = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    pragma: py3 no cover
+    if six.PY2
+    elif six.PY2
+
+partial_branches =
+    pragma: no cover
+    pragma: py3 no cover
+    if six.PY3
+    elif six.PY3
+
+show_missing = True
+
+fail_under = 90

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -12,7 +12,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py27,py36 -- test-toolkit/unit
+        tox -e py27,py36,py37 -- test-toolkit/unit
 
       # run local integ tests
       #- $(aws ecr get-login --no-include-email --region us-west-2)

--- a/buildspec-toolkit.yml
+++ b/buildspec-toolkit.yml
@@ -32,7 +32,7 @@ phases:
       - tox -e flake8,twine
 
       # run unit tests
-      - tox -e py36,py27 test-toolkit/unit
+      - tox -e py27,py36,py37 test-toolkit/unit
 
       # define tags
       - GENERIC_CPU_TAG="$FRAMEWORK_VERSION-mxnet-cpu-$BUILD_ID"

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,12 @@ setup(
         "Programming Language :: Python",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # support sagemaker-inference==1.1.0 for mxnet 1.4 eia image and
-    # sagemaker-inference==1.2.2 version for mxnet 1.6 image.
-    install_requires=['sagemaker-inference>=1.1.0,<=1.2.2', 'retrying==1.3.3'],
+    # sagemaker-inference==1.3.0 version for mxnet 1.6 image.
+    install_requires=['sagemaker-inference>=1.1.0,<=1.3.0', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'pytest-rerunfailures',
                  'mock', 'sagemaker==1.50.18', 'docker-compose', 'mxnet==1.4.0', 'awslogs', 'requests_mock']

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
 
     # support sagemaker-inference==1.1.0 for mxnet 1.4 eia image and
     # sagemaker-inference==1.3.0 version for mxnet 1.6 image.
-    install_requires=['sagemaker-inference>=1.1.0,<=1.3.0', 'retrying==1.3.3'],
+    install_requires=['sagemaker-inference>=1.1.0,<=1.3.1', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'pytest-rerunfailures',
                  'mock', 'sagemaker==1.50.18', 'docker-compose', 'mxnet==1.4.0', 'awslogs', 'requests_mock']

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 [tox]
-envlist = flake8,py27,py36
+envlist = flake8,py27,py36,py37
 skip_missing_interpreters = False
 
 [flake8]


### PR DESCRIPTION
*Description of changes:*
- Upgrade version of sagemaker-inference to `1.3.1`, which supports Python 3.7.
- Update tox and buildspecs to test against py37.
- Update Python version in `setup.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
