### PR TITLE
change: Install openssl from source in py3 1.5.1 EI image

### DIFF
--- a/docker/1.5.1/py3/Dockerfile.eia
+++ b/docker/1.5.1/py3/Dockerfile.eia
@@ -78,7 +78,10 @@ RUN pip install --no-cache-dir \
 RUN wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz \
  && apt-get remove --purge -y openssl \
  && rm -rf /usr/include/openssl \
- && apt-get update && apt-get install -y ca-certificates \
+ && apt-get update \
+ && apt-get install -y \
+    ca-certificates \
+    openjdk-8-jdk-headless \
  && tar -xzvf openssl-1.1.1g.tar.gz \
  && cd openssl-1.1.1g \
  && ./config \

--- a/docker/1.5.1/py3/Dockerfile.eia
+++ b/docker/1.5.1/py3/Dockerfile.eia
@@ -13,9 +13,11 @@ RUN apt-get update \
  && apt-get -y install --no-install-recommends \
     build-essential \
     ca-certificates \
+    checkinstall \
     curl \
     git \
     libopencv-dev \
+    libtemplate-perl \
     openjdk-8-jdk-headless \
     vim \
     wget \
@@ -71,6 +73,26 @@ RUN pip install --no-cache-dir \
     numpy==1.17.4 \
     onnx==1.4.1 \
     "sagemaker-mxnet-inference<2"
+
+# Install openssl-1.1.1g to override default openssl-1.0.2g
+RUN wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz \
+ && apt-get remove --purge -y openssl \
+ && rm -rf /usr/include/openssl \
+ && apt-get update && apt-get install -y ca-certificates \
+ && tar -xzvf openssl-1.1.1g.tar.gz \
+ && cd openssl-1.1.1g \
+ && ./config \
+ && make \
+ && make test \
+ && make install \
+ && cd ../ \
+ && rm -rf openssl-1.1.1g \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Purging default openssl in above command also prevents the new installation of openssl
+# from finding certificates at the pre-existing path. This env variable fixes the issue.
+ENV SSL_CERT_DIR=/etc/ssl/certs
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394


### PR DESCRIPTION
*Description of changes:*
Install latest openssl-1.1.1g from source to fix vulnerabilities raised by dependency-check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
