### PR TITLE
Fix handler service

### DIFF
--- a/src/sagemaker_mxnet_serving_container/handler_service.py
+++ b/src/sagemaker_mxnet_serving_container/handler_service.py
@@ -41,11 +41,6 @@ class HandlerService(DefaultHandlerService):
     Based on: https://github.com/awslabs/multi-model-server/blob/master/docs/custom_service.md
 
     """
-    def __init__(self):
-        # self._service = None
-        transformer = Transformer(default_inference_handler=DefaultMXNetInferenceHandler())
-        super(HandlerService, self).__init__(transformer=transformer)
-
     @staticmethod
     def _user_module_transformer(model_dir=environment.model_dir):
         try:
@@ -83,5 +78,10 @@ class HandlerService(DefaultHandlerService):
         else:
             os.environ[PYTHON_PATH_ENV] = code_dir_path
 
-        self._service = self._user_module_transformer(model_dir)
+        try:
+            self._service = self._user_module_transformer(model_dir)
+        except ValueError as e:
+             logging.error(f"Error determining model. {str(e)}. For non-mxnet models, consider using pytorch-inference DLC that leverages TorchServe.")
+             raise
+
         super(HandlerService, self).initialize(context)

--- a/src/sagemaker_mxnet_serving_container/handler_service.py
+++ b/src/sagemaker_mxnet_serving_container/handler_service.py
@@ -81,7 +81,8 @@ class HandlerService(DefaultHandlerService):
         try:
             self._service = self._user_module_transformer(model_dir)
         except ValueError as e:
-             logging.error(f"Error determining model. {str(e)}. For non-mxnet models, consider using pytorch-inference DLC that leverages TorchServe.")
-             raise
+            logging.error(f"Error determining model. {str(e)}. "
+                          "For non-mxnet models, consider using pytorch-inference DLC that leverages TorchServe.")
+            raise
 
         super(HandlerService, self).initialize(context)

--- a/src/sagemaker_mxnet_serving_container/handler_service.py
+++ b/src/sagemaker_mxnet_serving_container/handler_service.py
@@ -42,7 +42,9 @@ class HandlerService(DefaultHandlerService):
 
     """
     def __init__(self):
-        self._service = None
+        # self._service = None
+        transformer = Transformer(default_inference_handler=DefaultMXNetInferenceHandler())
+        super(HandlerService, self).__init__(transformer=transformer)
 
     @staticmethod
     def _user_module_transformer(model_dir=environment.model_dir):


### PR DESCRIPTION
*Issue #, if available:*
In cases where the model_fn does not return a model of type `mx.module.BaseModule` or `mx.gluon.block.Block` [see the method _user_module_transformer()], the model load succeeds, but the `self._service` object does not get assigned any transformer, leading to the error message:
```
'W-9000-model-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - AttributeError: 'NoneType' object has no attribute 'transform'
```

This PR addresses the issue by:
1. Removing the initialization of self._service to None in the mxnet handler, as it's already initialized in the base handler from which it inherits.
2. Raises the ValueError that is thrown by `_user_module_transformer()` to clarify the issue in case users use a non-mxnet model. Recommends them to use TorchServe for non-mxnet workloads (as the closest neighbor of MMS).

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
